### PR TITLE
Add device compatibility checks

### DIFF
--- a/OLMoE.swift/OLMoE_swiftApp.swift
+++ b/OLMoE.swift/OLMoE_swiftApp.swift
@@ -70,7 +70,6 @@ struct OLMoE_swiftApp: App {
     }
 }
 
-// AppDelegate for macOS and iOS
 class AppDelegate: NSObject, UIApplicationDelegate {
     func application(_ application: UIApplication, handleEventsForBackgroundURLSession identifier: String, completionHandler: @escaping () -> Void) {
         print("Background URL session: \(identifier)")


### PR DESCRIPTION
There is no way to set device SKU-level compatibility, only device family (iPad, iPhone, iPod, etc), and OS version.  So, I've written a SKU checker.  It checks for iPhones and iPads with 8GB of RAM, and does a physical memory check for Mac.