### PR TITLE
[#15] Disclaimer Text On App Start

### DIFF
--- a/OLMoE.swift.xcodeproj/project.pbxproj
+++ b/OLMoE.swift.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		48D976622CE57322008DB9FD /* keyboardDismiss.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48D976602CE57322008DB9FD /* keyboardDismiss.swift */; };
+		1AA5BE972CE56A54004CA83D /* DisclaimerPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AA5BE962CE56A4B004CA83D /* DisclaimerPageView.swift */; };
 		58133EF62CE535C60052EFAD /* SpinnerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58133EF52CE535C60052EFAD /* SpinnerView.swift */; };
 		A0117FEC2C990EAB00035007 /* OLMoE_swiftApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0117FEB2C990EAB00035007 /* OLMoE_swiftApp.swift */; };
 		A0117FEE2C990EAB00035007 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0117FED2C990EAB00035007 /* ContentView.swift */; };
@@ -25,6 +26,7 @@
 
 /* Begin PBXFileReference section */
 		48D976602CE57322008DB9FD /* keyboardDismiss.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = keyboardDismiss.swift; sourceTree = "<group>"; };
+		1AA5BE962CE56A4B004CA83D /* DisclaimerPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisclaimerPageView.swift; sourceTree = "<group>"; };
 		58133EF52CE535C60052EFAD /* SpinnerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerView.swift; sourceTree = "<group>"; };
 		A0117FE82C990EAB00035007 /* OLMoE.swift.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = OLMoE.swift.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A0117FEB2C990EAB00035007 /* OLMoE_swiftApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OLMoE_swiftApp.swift; sourceTree = "<group>"; };
@@ -95,6 +97,7 @@
 				A0117FEB2C990EAB00035007 /* OLMoE_swiftApp.swift */,
 				A0117FED2C990EAB00035007 /* ContentView.swift */,
 				58133EF52CE535C60052EFAD /* SpinnerView.swift */,
+				1AA5BE962CE56A4B004CA83D /* DisclaimerPageView.swift */,
 				A0117FEF2C990EAC00035007 /* Assets.xcassets */,
 				A0117FF12C990EAC00035007 /* OLMoE_swift.entitlements */,
 				A0117FF22C990EAC00035007 /* Preview Content */,
@@ -195,6 +198,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A046603D2CA3FAFA007BD14C /* Configuration.swift in Sources */,
+				1AA5BE972CE56A54004CA83D /* DisclaimerPageView.swift in Sources */,
 				A0117FEE2C990EAB00035007 /* ContentView.swift in Sources */,
 				A01180012C990F7600035007 /* LLM.swift in Sources */,
 				A011800C2C9A919D00035007 /* ModelDownloadView.swift in Sources */,

--- a/OLMoE.swift/ContentView.swift
+++ b/OLMoE.swift/ContentView.swift
@@ -325,6 +325,8 @@ struct ActivityViewController: UIViewControllerRepresentable {
 struct ContentView: View {
     @StateObject private var downloadManager = BackgroundDownloadManager.shared
     @State private var bot: Bot?
+    @State private var showDisclaimerPage : Bool = true
+    @State private var disclaimerPageIndex: Int = 0
 
     var body: some View {
         VStack {
@@ -339,9 +341,30 @@ struct ContentView: View {
                 initializeBot()
             }
         }
+        .popover(isPresented: $showDisclaimerPage) {
+            let page = Disclaimer.pages[disclaimerPageIndex]
+            DisclaimerPage(
+                title: page.title,
+                message: page.text,
+                confirm: DisclaimerPage.PageButton(
+                    text: page.buttonText,
+                    onDismiss: {
+                        nextInfoPage()
+                    })
+            )
+            .presentationBackground(Color("BackgroundColor"))
+        }
         .onAppear(perform: checkModelAndInitializeBot)
     }
 
+    private func nextInfoPage() {
+        disclaimerPageIndex = min(Disclaimer.pages.count, disclaimerPageIndex + 1)
+        if disclaimerPageIndex >= Disclaimer.pages.count {
+            disclaimerPageIndex = 0
+            showDisclaimerPage = false
+        }
+    }
+        
     private func checkModelAndInitializeBot() {
         if FileManager.default.fileExists(atPath: Bot.modelFileURL.path) {
             downloadManager.isModelReady = true

--- a/OLMoE.swift/DisclaimerPageView.swift
+++ b/OLMoE.swift/DisclaimerPageView.swift
@@ -1,0 +1,55 @@
+//
+//  DisclaimerPageView.swift
+//  OLMoE.swift
+//
+//  Created by Thomas Jones on 11/13/24.
+//
+
+import SwiftUI
+
+struct DisclaimerPageData {
+    let title: String
+    let text: String
+    let buttonText: String
+}
+
+// Placeholder disclaimer text displayed at app start
+enum Disclaimer {
+    static let pages = [
+        
+        DisclaimerPageData(title: "[TODO] Disclaimers",
+                           text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam odio urna, porta vel eleifend volutpat, porta vitae justo. Aenean sit amet sem id urna consectetur feugiat. Morbi in sem gravida orci rutrum maximus. Donec pretium accumsan orci quis elementum. Sed a tempor libero. Cras tempus nisl ut mattis pretium. Fusce in congue arcu. Vivamus nec sollicitudin est. Cras id eleifend nisl. Phasellus quis neque in leo accumsan fermentum et quis diam. Integer non lectus blandit, hendrerit ante sed, bibendum sapien. Etiam quis facilisis ante. Donec lacinia tincidunt est, quis volutpat est tincidunt et. Nullam nibh risus, tempor quis lacinia ac, dictum et arcu. Curabitur sit amet mauris id mi facilisis laoreet a non metus.",
+                           buttonText: "Next"),
+        
+        DisclaimerPageData(title: "[TODO] Additional Disclaimers",
+                           text: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam odio urna, porta vel eleifend volutpat, porta vitae justo. Aenean sit amet sem id urna consectetur feugiat. Morbi in sem gravida orci rutrum maximus. Donec pretium accumsan orci quis elementum. Sed a tempor libero. Cras tempus nisl ut mattis pretium. Fusce in congue arcu. Vivamus nec sollicitudin est. Cras id eleifend nisl. Phasellus quis neque in leo accumsan fermentum et quis diam. Integer non lectus blandit, hendrerit ante sed, bibendum sapien. Etiam quis facilisis ante. Donec lacinia tincidunt est, quis volutpat est tincidunt et. Nullam nibh risus, tempor quis lacinia ac, dictum et arcu. Curabitur sit amet mauris id mi facilisis laoreet a non metus.",
+                           buttonText: "I Agree")
+    ]
+}
+
+struct DisclaimerPage: View {
+    typealias PageButton = (text: String, onDismiss: () -> Void)
+    
+    let title: String
+    let message: String
+    let confirm: PageButton
+    
+    var body: some View {
+        VStack(spacing: 20) {
+            
+            Text(title)
+                .font(.headline)
+                .padding(.top, 20)
+            
+            Text(message)
+                .font(.body)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 20)
+            
+            Button(confirm.text) {
+                confirm.onDismiss()
+            }
+            .padding(.bottom, 20)
+        }
+    }
+}


### PR DESCRIPTION
Ticket: https://github.com/allenai/OLMoE.swift/issues/15
(Note: The file size check before download was handled in a different PR)

Create a simple 'disclaimer page' for disclaimer and legal text that pops up at app start. The current text is placeholder and we will need final copy.

The design of this page is likely to change if we want it to be styled more appropriately with images as a 'splash' page, for example.


https://github.com/user-attachments/assets/e47a500d-d431-482c-a108-3e45c961f636

