### PR TITLE
[#3] Disable the text field when the response is generating.

### DIFF
--- a/OLMoE.swift/ContentView.swift
+++ b/OLMoE.swift/ContentView.swift
@@ -43,6 +43,10 @@ struct BotView: View {
     @State private var showShareSheet = false
     @State private var isSharingConfirmationVisible = false
     @FocusState private var isTextEditorFocused: Bool
+
+    private var isInputDisabled: Bool {
+        isGenerating || isSharing
+    }
     
     init(_ bot: Bot) {
         _bot = StateObject(wrappedValue: bot)
@@ -239,6 +243,8 @@ struct BotView: View {
                                     self.hideKeyboard()
                                 }
                             })
+                            .disabled(isInputDisabled)
+                            .opacity(isInputDisabled ? 0.6 : 1)
                         
                         if input.isEmpty {
                             Text("Message")


### PR DESCRIPTION
# Describe the changes
While the Ai response is generating, the text field is now disabled and becomes enabled once the response has stopped.
It also becomes disabled while sharing.

The text field is available for input. Once the prompt is submitted, the text field is unavailable. After the Ai has finished responding, the text field is available again.

https://github.com/user-attachments/assets/86c6878a-a096-4609-9907-8f71f8b725a3


The text field is available for input after the Ai has finished responding. When the share button is pressed, the text field is unavailable. The text field remains unavailable until after the sharing is complete after which, it becomes available again.

https://github.com/user-attachments/assets/04326564-e76a-4707-9b5c-4869ac90ece3


## Issue ticket number and link
#3 