### PR TITLE
Undo inadvertent change that disabled saving disclaimer view

### DIFF
--- a/OLMoE.swift/Views/ContentView.swift
+++ b/OLMoE.swift/Views/ContentView.swift
@@ -473,7 +473,7 @@ struct ActivityViewController: UIViewControllerRepresentable {
 struct ContentView: View {
     @StateObject private var downloadManager = BackgroundDownloadManager.shared
     @State private var bot: Bot?
-    @AppStorage("hasSeenDisclaimer__") private var hasSeenDisclaimer : Bool = false
+    @AppStorage("hasSeenDisclaimer") private var hasSeenDisclaimer : Bool = false
     @State private var showDisclaimerPage : Bool = false
     @State private var showInfoPage : Bool = false
     @State private var disclaimerPageIndex: Int = 0
@@ -546,7 +546,7 @@ struct ContentView: View {
         if disclaimerPageIndex >= disclaimers.count {
             disclaimerPageIndex = 0
             showDisclaimerPage = false
-            //hasSeenDisclaimer = true
+            hasSeenDisclaimer = true
         }
     }
         


### PR DESCRIPTION
A tiny change snuck in that was used to ensure the disclaimers continued to pop-up.