### PR TITLE
Add Surface Colors, default dark mode

### DIFF
--- a/OLMoE.swift/Assets.xcassets/Surface.colorset/Contents.json
+++ b/OLMoE.swift/Assets.xcassets/Surface.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x57",
+          "green" : "0x52",
+          "red" : "0x10"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x57",
+          "green" : "0x52",
+          "red" : "0x10"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/OLMoE.swift/OLMoE_swiftApp.swift
+++ b/OLMoE.swift/OLMoE_swiftApp.swift
@@ -8,7 +8,9 @@ struct OLMoE_swiftApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .font(.manrope())
+                .environment(\.font, .manrope())
+                .environment(\.colorScheme, .dark)
+                
         }
     }
 }

--- a/OLMoE.swift/Views/ContentView.swift
+++ b/OLMoE.swift/Views/ContentView.swift
@@ -377,12 +377,10 @@ struct BotView: View {
                             .scrollContentBackground(.hidden)
                             .background(
                                 RoundedRectangle(cornerRadius: 8)
+                                    .fill(Color("Surface"))
                                     .foregroundStyle(.thinMaterial)
                             )
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 8)
-                                    .stroke(Color("TextColor").opacity(0.2), lineWidth: 1)
-                            )
+                            .clipShape(RoundedRectangle(cornerRadius: 8))
                             .foregroundColor(Color("TextColor"))
                             .font(.manrope())
                             .focused($isTextEditorFocused)


### PR DESCRIPTION
# changes
- Make dark mode active by default
- Add surface color
- Remove text editor border
- Add surface color to text editor

Note: overlays and popovers still require to set bakground color manually