### PR TITLE
Chat Improvement - User message in history

### DIFF
--- a/OLMoE.swift/Model/LLM.swift
+++ b/OLMoE.swift/Model/LLM.swift
@@ -392,6 +392,11 @@ open class LLM: ObservableObject {
         inferenceTask = Task { [weak self] in
             guard let self = self else { return }
             
+            await MainActor.run {
+                // Append user's message to history prior to response generation
+                self.history.append((.user, input))
+            }
+            
             self.input = input
             let processedInput = self.preprocess(input, self.history)
             let responseStream = loopBackTestResponse ? self.getTestLoopbackResponse() : self.getResponse(from: processedInput)
@@ -401,7 +406,6 @@ open class LLM: ObservableObject {
             
             await MainActor.run {
                 // Update history and process the final output on the main actor
-                self.history.append((.user, input))
                 self.history.append((.bot, output))
                 
                 // Maintain the history limit


### PR DESCRIPTION
Task: https://github.com/allenai/OLMoE.swift/issues/3

Improve chat usability by appending the user message to chat history before response generation. Prior to this, the chat message history doesn't update until the response is finished generating, which feels strange when the user's last message finally gets added only when the response completes.