### PR TITLE
Restore hide keyboard

### DIFF
--- a/OLMoE.swift/Views/ContentView.swift
+++ b/OLMoE.swift/Views/ContentView.swift
@@ -357,6 +357,7 @@ struct BotView: View {
                 MessageInputView(
                     input: $input,
                     isGenerating: $isGenerating,
+                    isTextEditorFocused: $isTextEditorFocused,
                     isInputDisabled: isInputDisabled,
                     hasValidInput: hasValidInput,
                     respond: respond,

--- a/OLMoE.swift/Views/InputMessage.swift
+++ b/OLMoE.swift/Views/InputMessage.swift
@@ -10,8 +10,7 @@ import SwiftUI
 struct MessageInputView: View {
     @Binding var input: String
     @Binding var isGenerating: Bool
-    @FocusState private var isTextEditorFocused: Bool
-    
+    @FocusState.Binding var isTextEditorFocused: Bool
     let isInputDisabled: Bool
     let hasValidInput: Bool
     let respond: () -> Void
@@ -69,9 +68,12 @@ struct MessageInputView: View {
 }
 
 #Preview {
+    @FocusState var isTextEditorFocused: Bool
+    
     MessageInputView(
         input: .constant("Message"),
         isGenerating: .constant(false),
+        isTextEditorFocused: $isTextEditorFocused,
         isInputDisabled: false,
         hasValidInput: true,
         respond: {


### PR DESCRIPTION
# Describe the changes

Somewhere when extracting the input message into it's own component, the funcitonality that hides the keyboard when it loses focus  got lost. This PR restores it.

#Issue
#8 