### PR TITLE
Fixed invalid frame size message.

### DIFF
--- a/OLMoE.swift/Views/ContentView.swift
+++ b/OLMoE.swift/Views/ContentView.swift
@@ -252,7 +252,7 @@ struct BotView: View {
             }
             .foregroundColor(Color("TextColor"))
         }
-       .disabled(isSharing || bot.history.isEmpty)
+        .disabled(isSharing || bot.history.isEmpty)
         .opacity(isSharing || bot.history.isEmpty ? 0.5 : 1)
     }
 


### PR DESCRIPTION
# Describe the changes
The app always reports "Invalid frame dimension". The width of the Splash was generated with math, but could potentially be infinitely small as it only used `min`. Ensure it is never smaller than 140.

![image](https://github.com/user-attachments/assets/fbe35aab-82fd-41f6-9f7f-fb427b8eefe6)
