### PR TITLE
[8] iPad Modal Width

### DIFF
--- a/OLMoE.swift/Views/ModalView.swift
+++ b/OLMoE.swift/Views/ModalView.swift
@@ -59,7 +59,7 @@ struct ModalView<Content: View>: View {
                         .frame(maxHeight: min(contentHeight, proxy.size.height - 100))
                         .padding(.bottom, 24)
                     }
-                    .frame(minWidth: 300, maxWidth: min(302, proxy.size.width - 48))
+                    .frame(minWidth: 300, maxWidth: min(600, proxy.size.width - 48))
                     .padding(.horizontal, 12)
                     .background(Color("Surface"))
                     .cornerRadius(12)


### PR DESCRIPTION
Task: https://github.com/allenai/OLMoE.swift/issues/8

Define a larger maximum for the minimum allowed with for the modal so it looks better on iPad.

I used this as a reference to see the logical widths of the various devices and picked a number that looks good for a few different iPad sizes (and still looks the same on a phone). https://www.ios-resolution.com/

<img width="1673" alt="ai2-ipad-modal-1" src="https://github.com/user-attachments/assets/4ee3f263-2d53-495b-ba6b-da9087b5f01f">

<img width="1676" alt="ai2-ipad-modal-2" src="https://github.com/user-attachments/assets/071ed214-d94a-42cc-a2b6-3e250fe7b0b2">

<img width="1677" alt="ai2-ipad-modal-3" src="https://github.com/user-attachments/assets/1cfc1232-40c8-4fc8-9131-a0f23cf42092">
