### PR TITLE
Add default bubble with localized strings

### DIFF
--- a/OLMoE.swift.xcodeproj/project.pbxproj
+++ b/OLMoE.swift.xcodeproj/project.pbxproj
@@ -299,6 +299,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -355,6 +356,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_EMIT_LOC_STRINGS = YES;
 			};
 			name = Release;
 		};

--- a/OLMoE.swift.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/OLMoE.swift.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/OLMoE.swift/Constants/Localizable.xcstrings
+++ b/OLMoE.swift/Constants/Localizable.xcstrings
@@ -1,0 +1,71 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "(The model requires ~6 GB and this device has: %@ GB available.)" : {
+     
+    },
+    "%@ / %@" : {
+     
+    },
+    "%lld%%" : {
+
+    },
+    "allenai.org" : {
+
+    },
+    "Cancel" : {
+
+    },
+    "Delete" : {
+
+    },
+    "Delete history?" : {
+
+    },
+    "Device Not Supported" : {
+
+    },
+    "Download Model" : {
+
+    },
+    "Downloading..." : {
+
+    },
+    "Flush Model" : {
+
+    },
+    "Message" : {
+
+    },
+    "Model is ready to use!" : {
+
+    },
+    "Proceed Anyway" : {
+
+    },
+    "Proceed With Mocked Model" : {
+
+    },
+    "This app requires a device with at least 8GB of RAM." : {
+
+    },
+    "To get started, download the latest AI model." : {
+
+    },
+    "Welcome" : {
+
+    },
+    "Welcome chat message" : {
+      "comment" : "Default chat bubble when conversation is empty",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hello! This can be some kind of default welcome message."
+          }
+        }
+      }
+    }
+  },
+  "version" : "1.0"
+}

--- a/OLMoE.swift/Views/ContentView.swift
+++ b/OLMoE.swift/Views/ContentView.swift
@@ -58,6 +58,10 @@ struct BotView: View {
     private var isDeleteButtonDisabled: Bool {
         isInputDisabled || bot.history.isEmpty
     }
+    
+    private var isChatEmpty: Bool {
+        bot.history.isEmpty && !isGenerating && bot.output.isEmpty
+    }
 
     init(_ bot: Bot, disclaimerHandlers: DisclaimerHandlers) {
         _bot = StateObject(wrappedValue: bot)
@@ -259,7 +263,7 @@ struct BotView: View {
                 .edgesIgnoringSafeArea(.all)
 
             VStack(alignment: .leading) {
-                if !bot.output.isEmpty || isGenerating || !bot.history.isEmpty {
+                if !isChatEmpty {
                     ScrollViewReader { proxy in
                         ZStack {
                             ChatView(history: bot.history, output: bot.output, isGenerating: $isGenerating, isScrolledToBottom: $isScrolledToBottom)
@@ -303,6 +307,10 @@ struct BotView: View {
                 }
                 
                 Spacer()
+                
+                if (isChatEmpty) {
+                    BotChatBubble(text: String(localized: "Welcome chat message", comment: "Default chat bubble when conversation is empty"))
+                }
 
                 MessageInputView(
                     input: $input,


### PR DESCRIPTION
# Describe the changes
- Add default chat message bubble for empty chats
- Add String catalog for localized strings using Apple's guide: https://developer.apple.com/documentation/Xcode/localizing-and-varying-text-with-a-string-catalog

What’s great about String Catalogs in Xcode is that they update automatically when they find new Text or Button views. You don’t need to manually add each new Text or Button view to the file, as it updates automatically with the string itself as the key. If no value is provided, it shows the key by default. This makes it easy to add as many strings as you need and to include new languages later.

# Demo
![image](https://github.com/user-attachments/assets/120c1dc9-1434-415f-8ec6-8391aa18bb8f)

![image](https://github.com/user-attachments/assets/78200d69-a65d-4193-9f08-747f67c12fb4)

## Issue ticket number and link
#84 

## Checklist before requesting a review

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes and ensured that they work as expected.
- [x] I have updated examples and documentation as necessary.