### PR TITLE
[92] LLM Input / Output Debugging - Fix Duplicate 'Input'

### DIFF
--- a/OLMoE.swift/Model/LLM.swift
+++ b/OLMoE.swift/Model/LLM.swift
@@ -392,13 +392,14 @@ open class LLM: ObservableObject {
         inferenceTask = Task { [weak self] in
             guard let self = self else { return }
             
+            let historyBeforeInput = self.history
             await MainActor.run {
                 // Append user's message to history prior to response generation
                 self.history.append((.user, input))
             }
             
             self.input = input
-            let processedInput = self.preprocess(input, self.history)
+            let processedInput = self.preprocess(input, historyBeforeInput)            
             let responseStream = loopBackTestResponse ? self.getTestLoopbackResponse() : self.getResponse(from: processedInput)
             
             // Generate the output string using the async closure


### PR DESCRIPTION
This fixes issue where user's input message was duplicated in the prompt. This was caused when we appended the user's input to history before waiting for the response. The simple fix is to supply the history before the input was added.


> <|endoftext|><|user|>
> Test
> <|assistant|>
> Hello! How can I help you today? If you have any questions or need assistance, feel free to ask.
> <|user|>
> Hello, this is a message.
> <|assistant|>
> Hello, this is a message. Is there something specific you'd like to ask or discuss? If you need assistance or have questions, feel free to let me know!
> <|user|>
> Message 3.
> <|user|>
> Message 3.            <-- duplicate input message
> <|assistant|>
