### PR TITLE
Chat bubbles should always be 3/4 width

### DIFF
--- a/OLMoE.swift/Views/ChatView.swift
+++ b/OLMoE.swift/Views/ChatView.swift
@@ -18,7 +18,7 @@ public struct UserChatBubble: View {
                 .padding(12)
                 .background(Color("Surface"))
                 .cornerRadius(12)
-                .frame(maxWidth: 296, alignment: .trailing)
+                .frame(maxWidth: UIScreen.main.bounds.width * 0.75, alignment: .trailing)
                 .font(.body())
         }
     }
@@ -30,21 +30,21 @@ public struct BotChatBubble: View {
 
     public var body: some View {
         HStack(alignment: .top, spacing: 6) {
-            
+
             Image("BotProfilePicture")
                 .resizable()
                 .frame(width: 20, height: 20)
                 .padding(4)
                 .background(Color("Surface"))
                 .clipShape(Circle())
-            
+
             if isGenerating && text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 TypingIndicator()
             } else {
                 Text(text.trimmingCharacters(in: .whitespacesAndNewlines))
                     .padding(.top, -2)
                     .background(Color("BackgroundColor"))
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .frame(maxWidth: UIScreen.main.bounds.width * 0.75, alignment: .leading)
                     .font(.body())
             }
 
@@ -72,41 +72,41 @@ public struct TypingIndicator: View {
 struct ScrollState {
     static let BottomScrollThreshold = 120.0
     static let ScrollSpaceName: String = "scrollSpace"
-    
+
     public var scrollViewHeight: CGFloat = 0
     public var contentHeight: CGFloat = 0
     public var scrollOffset: CGFloat = 0
     public var isAtBottom: Bool = true
-    
+
     mutating func onScroll(scrollOffset: CGFloat) {
         self.scrollOffset = scrollOffset
         updateState()
     }
-    
+
     mutating func onContentResized(contentHeight: CGFloat) {
         self.contentHeight = contentHeight
         updateState()
     }
-    
+
     private mutating func updateState() {
         let needsScroll = contentHeight > scrollViewHeight
         let sizeDelta = contentHeight - scrollViewHeight
         let offsetDelta = abs(sizeDelta) + scrollOffset
         let isAtBottom = !needsScroll || offsetDelta < ScrollState.BottomScrollThreshold
-        self.isAtBottom = isAtBottom        
+        self.isAtBottom = isAtBottom
     }
 }
 
 public struct ChatView: View {
     public static let BottomID1 = "bottomID"
     public static let BottomID2 = "bottomID2"
-    
+
     public var history: [Chat]
     public var output: String
     @Binding var isGenerating: Bool
     @Binding var isScrolledToBottom: Bool
     @State private var scrollState = ScrollState()
-    
+
     public var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 10) {
@@ -121,7 +121,7 @@ public struct ChatView: View {
                         }
                     }
                 }
-                
+
                 // Current output
                 BotChatBubble(text: output, isGenerating: isGenerating)
                     .id(ChatView.BottomID1) // Unique ID for scrolling
@@ -138,7 +138,7 @@ public struct ChatView: View {
         .coordinateSpace(name: ScrollState.ScrollSpaceName)
         .preferredColorScheme(.dark)
     }
-    
+
     @ViewBuilder
     private func scrollTracker() -> some View {
         GeometryReader { geo in
@@ -156,7 +156,7 @@ public struct ChatView: View {
                 }
         }
     }
-    
+
     @ViewBuilder
     private func scrollHeightTracker() -> some View {
         GeometryReader { proxy in


### PR DESCRIPTION
# Describe the changes
Instead of defining the width of the chats, define them as 75% of the width of the UI.

On iPad:
<img src="https://github.com/user-attachments/assets/9fc9a985-059e-4151-9452-b57b8ee1c2e8" alt="Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-12-03 at 09 37 15" width="350">

On iPhone:
<img src="https://github.com/user-attachments/assets/dae51020-eba4-4ce6-b224-93c1e40c7881" alt="Simulator Screenshot - iPhone 16 - 2024-12-03 at 09 49 08" width="200">


## Issue ticket number and link
#78 

## Checklist before requesting a review

- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my code.
- [X] I have tested my changes and ensured that they work as expected.
- [X] I have updated examples and documentation as necessary.
