### PR TITLE
Doubled the height of the TextInput on iPad

### DIFF
--- a/OLMoE.swift/Views/ChatView.swift
+++ b/OLMoE.swift/Views/ChatView.swift
@@ -47,7 +47,6 @@ public struct BotChatBubble: View {
                     .frame(maxWidth: UIScreen.main.bounds.width * 0.75, alignment: .leading)
                     .font(.body())
             }
-
             Spacer()
         }
     }
@@ -132,9 +131,7 @@ public struct ChatView: View {
             .foregroundColor(Color("TextColor"))
             .background(scrollTracker())
         }
-        .background(
-            scrollHeightTracker()
-        )
+        .background(scrollHeightTracker())
         .coordinateSpace(name: ScrollState.ScrollSpaceName)
         .preferredColorScheme(.dark)
     }
@@ -205,4 +202,12 @@ public struct ChatView: View {
     )
     .padding(12)
     .background(Color("BackgroundColor"))
+}
+
+#Preview("BotChatBubble") {
+    BotChatBubble(text: "Welcome chat message")
+}
+
+#Preview("UserChatBubble") {
+    UserChatBubble(text: "Hello Ai, please help me with your knowledge.")
 }

--- a/OLMoE.swift/Views/MessageInputView.swift
+++ b/OLMoE.swift/Views/MessageInputView.swift
@@ -15,7 +15,7 @@ struct MessageInputView: View {
     let hasValidInput: Bool
     let respond: () -> Void
     let stop: () -> Void
-    
+
     var body: some View {
         HStack(alignment: .top) {
             TextField("Message", text: $input, axis: .vertical)
@@ -33,7 +33,7 @@ struct MessageInputView: View {
                 .disabled(isInputDisabled)
                 .opacity(isInputDisabled ? 0.6 : 1)
                 .padding(12)
-            
+
             ZStack {
                 if isGenerating {
                     Button(action: stop) {
@@ -55,20 +55,21 @@ struct MessageInputView: View {
             .frame(width: 40, height: 40)
             .padding(.top, 2)
             .padding(.trailing, 4)
-            
+
         }
+        .frame(maxWidth: .infinity)
+        .frame(minHeight: UIDevice.current.userInterfaceIdiom == .pad ? 80 : 40)
         .background(
             RoundedRectangle(cornerRadius: 12)
                 .fill(Color("Surface"))
                 .foregroundStyle(.thinMaterial)
         )
-        .frame(maxWidth: .infinity)
     }
 }
 
 #Preview {
     @FocusState var isTextEditorFocused: Bool
-    
+
     MessageInputView(
         input: .constant("Message"),
         isGenerating: .constant(false),


### PR DESCRIPTION
# Describe the changes
Doubled the height of the TextField when on iPad. 

iPad with no input:
<img src="https://github.com/user-attachments/assets/f5661456-a7ff-43c9-b1d5-df341f665780" alt="Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-12-03 at 14 46 13" width=350>

iPad with a single line of text:
<img src="https://github.com/user-attachments/assets/e91638b1-b923-4968-b224-997b0621fdd8" alt="Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-12-03 at 14 47 29" width=350>

iPad with multiple lines of text:
<img src="https://github.com/user-attachments/assets/5f91fd9a-950c-4f89-90f9-90c819380e6c" alt="Simulator Screenshot - iPad Pro 13-inch (M4) - 2024-12-03 at 14 48 23" width=350>

iPhone with no input:
<img src="https://github.com/user-attachments/assets/6344dbdc-9a7a-4d4e-ad9e-da064c66b7e4" alt="Simulator Screenshot - iPhone 16 - 2024-12-03 at 14 44 11" width=200>

iPhone with a single line of text:
<img src="https://github.com/user-attachments/assets/d18811a6-dbb7-4a48-a9ce-6d25ae0c4a88" alt="Simulator Screenshot - iPhone 16 - 2024-12-03 at 14 44 30" width=200>

iPhone with multiple lines of text:
<img src="https://github.com/user-attachments/assets/1d2f6c47-e1e5-4200-9f07-3e74887d1676" alt="Simulator Screenshot - iPhone 16 - 2024-12-03 at 14 45 43" width=200>

## Issue ticket number and link
#78

## Checklist before requesting a review

- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my code.
- [X] I have tested my changes and ensured that they work as expected.
- [X] I have updated examples and documentation as necessary.
- [X] I have incremented the version number in the appropriate files.
