### PR TITLE
Lock Llama CPP Version

### DIFF
--- a/OLMoE.swift.xcodeproj/project.pbxproj
+++ b/OLMoE.swift.xcodeproj/project.pbxproj
@@ -479,8 +479,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/ggerganov/llama.cpp/";
 			requirement = {
-				branch = master;
-				kind = branch;
+				kind = revision;
+				revision = cc98896db858df7aa40d0e16a505883ef196a482;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/OLMoE.swift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OLMoE.swift.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ggerganov/llama.cpp/",
       "state" : {
-        "branch" : "master",
-        "revision" : "23e0d70bacaaca1429d365a44aa9e7434f17823b"
+        "revision" : "cc98896db858df7aa40d0e16a505883ef196a482"
       }
     }
   ],


### PR DESCRIPTION
Lock the llama CPP version to a specific, updated  commit that we've verified works well. The primary reason for this is to ensure all developers have the exact same version of the dependency, which is a recent, tested version. This new version seems to utilize the GPU more.

https://github.com/ggerganov/llama.cpp/releases/tag/b4255

Examples of the diff of llama logs in the app between the older and newer versions.

<img width="1332" alt="llama-diff-startup" src="https://github.com/user-attachments/assets/7259700f-8cb0-4ea3-857d-de8ea02d6540">

<img width="1277" alt="llama-diff-prompt-2" src="https://github.com/user-attachments/assets/783ccca4-c0d1-4667-a4a5-1ad276ee2f04">
