### PR TITLE
Miscellaneous QOL fixes

### DIFF
--- a/OLMoE.swift/Views/ContentView.swift
+++ b/OLMoE.swift/Views/ContentView.swift
@@ -268,14 +268,13 @@ struct BotView: View {
                 if !isChatEmpty {
                     ScrollViewReader { proxy in
                         ZStack {
-                            ChatView(history: bot.history, output: bot.output, isGenerating: $isGenerating, isScrolledToBottom: $isScrolledToBottom)
+                            ChatView(history: bot.history, output: bot.output.trimmingCharacters(in: .whitespacesAndNewlines), isGenerating: $isGenerating, isScrolledToBottom: $isScrolledToBottom)
                                 .onChange(of: bot.output) { _, _ in
                                     if isScrolledToBottom {
                                         withAnimation {
                                             proxy.scrollTo(ChatView.BottomID, anchor: .bottom)
                                         }
                                     }
-                                    
                                 }
                                 .onChange(of: scrollToBottom) { _, newValue in
                                     if newValue {


### PR DESCRIPTION
# Describe the changes

## 1) Scroll to bottom after sending a new message

### Before
https://github.com/user-attachments/assets/878950f7-e92b-4b43-9aa1-7315ec639356

### After
https://github.com/user-attachments/assets/7b2976ad-df31-4df9-9c0f-d4deef8becfb

## 2) Avoid clearing input message prematurely on Delete button tapped

### Before
https://github.com/user-attachments/assets/e66f2bee-f7c6-4abf-b407-9e971b54ed58

### After
https://github.com/user-attachments/assets/6a1cfa7c-8745-4cdd-a4eb-4e601626c3d2

## 3) Trim output at the view level
Fix this problem:
![image](https://github.com/user-attachments/assets/7f18565b-38ee-4549-b9ab-7f4c4456724c)

Reason: The output is generated as a stream, applying trimming to each generated token is troublesome. 
Solution: Apply trimming to the final output at the view level

