### PR TITLE
Fix add message transition flickering

### DIFF
--- a/OLMoE.swift/Views/ContentView.swift
+++ b/OLMoE.swift/Views/ContentView.swift
@@ -88,7 +88,6 @@ struct BotView: View {
 
     func stop() {
         bot.stop()
-        isGenerating = false
     }
 
     func deleteHistory() {


### PR DESCRIPTION
# Describe the changes
- When tapping 'Stop', the variable `isGenerating` was being set to true prematurely. Since stopping is already handled by outputting the end token from llama.cpp in the `respond` method. Removing this unnecessary assignment allows history to be rendered on time without flickering.

## Before
https://github.com/user-attachments/assets/0f234eab-bee7-4360-8538-5b7037886224

## After
https://github.com/user-attachments/assets/84962ca2-c5b0-4580-9ec9-c76f1e4f50fc

