### PR TITLE
Left align HeaderTextPairViews

### DIFF
--- a/OLMoE.swift/Views/DisclaimerPageView.swift
+++ b/OLMoE.swift/Views/DisclaimerPageView.swift
@@ -91,8 +91,10 @@ struct DisclaimerPage: View {
                         .multilineTextAlignment(.leading)
                 }
 
-                ForEach(titleText) { t in
-                    HeaderTextPairView(header: t.header, text: t.text)
+                VStack(alignment: .leading, spacing: 20) {
+                    ForEach(titleText) { t in
+                        HeaderTextPairView(header: t.header, text: t.text)
+                    }
                 }
 
                 HStack(spacing: 12) {


### PR DESCRIPTION
# Describe the changes
Aligned the HeaderTextPairViews left in a VStack wrapper.

(The yellow boxes are not in the PR)
<img src="https://github.com/user-attachments/assets/b212d567-76f7-4d59-b204-bae112370bb6" alt="Simulator Screenshot - iPhone 16 - 2024-12-05 at 16 17 59" width=250>


## Checklist before requesting a review

- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my code.
- [X] I have tested my changes and ensured that they work as expected.