### PR TITLE
LLM Save/Restore Feature Flag + Troublehsooting

### DIFF
--- a/OLMoE.swift/Constants/FeatureFlags.swift
+++ b/OLMoE.swift/Constants/FeatureFlags.swift
@@ -11,4 +11,6 @@ enum FeatureFlags {
     static let allowDeviceBypass = true
     
     static let allowMockedModel = true
+    
+    static let useLLMCaching = true
 }


### PR DESCRIPTION
Add LLM caching feature flag and troubleshoot the context lifetime. I think we still need to nail down the lifecycle of the context, the defer block is still wiping it out before save can happen. Here I conditionally allow the context to clear only if the cachig feature is on, but it ends up breaking later, possibly memory or some conflicting state related?

<img width="1259" alt="ai2-llama-crash-with-caching" src="https://github.com/user-attachments/assets/e66800a8-9f57-4dbb-91da-45eefe7a205f">
