### PR TITLE
Disable 'Device Bypass' Feature

### DIFF
--- a/OLMoE.swift/Constants/FeatureFlags.swift
+++ b/OLMoE.swift/Constants/FeatureFlags.swift
@@ -8,9 +8,9 @@
 
 enum FeatureFlags {
 
-    static let allowDeviceBypass = true
+    static let allowDeviceBypass = false
 
-    static let allowMockedModel = true
+    static let allowMockedModel = false
 
     static let useLLMCaching = true
 }


### PR DESCRIPTION
Disable the feature flags for bypassing the model / device constraint - a feature used for testing the UI on device even if a device can't run the model. This removes the button to 'proceed anyway' or 'proceed mocked'

<img width="403" alt="ai2-bypass-disabled" src="https://github.com/user-attachments/assets/cdad8ce7-4ae7-4d78-a234-00146c827fae" />
