### PR TITLE
[P1] Country support for conversation sharing

### DIFF
--- a/OLMoE.swift/Constants/FeatureFlags.swift
+++ b/OLMoE.swift/Constants/FeatureFlags.swift
@@ -5,12 +5,20 @@
 //  Created by Thomas Jones on 11/15/24.
 //
 
+import DeviceCheck
 
-enum FeatureFlags {
+public enum FeatureFlags {
 
     static let allowDeviceBypass = false
+
+    static let serverSideSharing: Bool = {
+        let appAttestService = DCAppAttestService()
+        return Locale.isCountrySupported() && appAttestService.isSupported
+    }()
 
     static let allowMockedModel = false
 
     static let useLLMCaching = true
+
+
 }

--- a/OLMoE.swift/Extensions/Locale+CountrySupport.swift
+++ b/OLMoE.swift/Extensions/Locale+CountrySupport.swift
@@ -1,0 +1,24 @@
+//
+//  Locale+CountrySupport.swift
+//  OLMoE.swift
+//
+//  Created by Stanley Jovel on 3/5/25.
+//
+
+import Foundation
+
+extension Locale {
+    static let supportedCountries = ["US"]
+    
+    /// Check if the user's country supports server-side sharing
+    static func isCountrySupported() -> Bool {
+        let userCountry: String?
+        if #available(iOS 16, *) {
+            userCountry = Locale.current.region?.identifier
+        } else {
+            userCountry = Locale.current.regionCode
+        }
+        
+        return userCountry.map { supportedCountries.contains($0) } ?? false
+    }
+}

--- a/OLMoE.swift/Views/ContentView.swift
+++ b/OLMoE.swift/Views/ContentView.swift
@@ -233,7 +233,7 @@ struct BotView: View {
             ToolbarButton(action: {
                 isTextEditorFocused = false
 
-                if Locale.isCountrySupported() {
+                if FeatureFlags.serverSideSharing {
                     // For supported countries, use the disclaimer and shareConversation flow
                     disclaimerHandlers.setActiveDisclaimer(Disclaimers.ShareDisclaimer())
                     disclaimerHandlers.setCancelAction({ disclaimerHandlers.setShowDisclaimerPage(false) })

--- a/OLMoE.swift/Views/ContentView.swift
+++ b/OLMoE.swift/Views/ContentView.swift
@@ -232,12 +232,18 @@ struct BotView: View {
         } else {
             ToolbarButton(action: {
                 isTextEditorFocused = false
-                // disclaimerHandlers.setActiveDisclaimer(Disclaimers.ShareDisclaimer())
-                // disclaimerHandlers.setCancelAction({ disclaimerHandlers.setShowDisclaimerPage(false) })
-                // disclaimerHandlers.setAllowOutsideTapDismiss(true)
-                // disclaimerHandlers.setConfirmAction({ shareConversation() })
-                // disclaimerHandlers.setShowDisclaimerPage(true)
-                showTextShareSheet = true
+
+                if Locale.isCountrySupported() {
+                    // For supported countries, use the disclaimer and shareConversation flow
+                    disclaimerHandlers.setActiveDisclaimer(Disclaimers.ShareDisclaimer())
+                    disclaimerHandlers.setCancelAction({ disclaimerHandlers.setShowDisclaimerPage(false) })
+                    disclaimerHandlers.setAllowOutsideTapDismiss(true)
+                    disclaimerHandlers.setConfirmAction({ shareConversation() })
+                    disclaimerHandlers.setShowDisclaimerPage(true)
+                } else {
+                    // For unsupported countries, use the text share sheet
+                    showTextShareSheet = true
+                }
             }, imageName: "square.and.arrow.up")
              .disabled(isSharing || bot.history.isEmpty || isGenerating)
              .opacity(isSharing || bot.history.isEmpty || isGenerating ? 0.5 : 1)


### PR DESCRIPTION
# Describe the changes
- Check for country when share button is tapped, if the country is in a list of supported countries (right now just the US is in that list) then server-side share is executed, otherwise share text locally.

## Issue ticket number and link
#169 

## DEMO
- When region is US, a disclaimber before sharing appears and a request is post to the share lambda. A link to the conversation is shared.

https://github.com/user-attachments/assets/05bd1c3d-ce70-4816-8af7-239547ff5576

- When region is different than US (i.e. UK), the conversation is shared as plaintext:

https://github.com/user-attachments/assets/3d40df44-a431-4fd1-b3f6-9cc360865866


## Checklist before requesting a review

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes and ensured that they work as expected.
- [x] I have updated examples and documentation as necessary.
