### PR TITLE
Use SF Symbols for toolbar buttons in MacOS

### DIFF
--- a/OLMoE.swift/Views/ContentView.swift
+++ b/OLMoE.swift/Views/ContentView.swift
@@ -231,7 +231,7 @@ struct BotView: View {
             SpinnerView(color: Color("AccentColor"))
         } else {
             let isDisabled = isSharing || bot.history.isEmpty || isGenerating
-            ToolbarButton(action: {
+            let action = {
                 isTextEditorFocused = false
                 // disclaimerHandlers.setActiveDisclaimer(Disclaimers.ShareDisclaimer())
                 // disclaimerHandlers.setCancelAction({ disclaimerHandlers.setShowDisclaimerPage(false) })
@@ -239,25 +239,40 @@ struct BotView: View {
                 // disclaimerHandlers.setConfirmAction({ shareConversation() })
                 // disclaimerHandlers.setShowDisclaimerPage(true)
                 showTextShareSheet = true
-            }, assetName: "ShareIcon", foregroundColor: Color("AccentColor"))
-             .disabled(isDisabled)
+            }
+
+            #if targetEnvironment(macCatalyst)
+            ToolbarButton(action: action, systemName: "square.and.arrow.up", foregroundColor: Color("AccentColor"))
+                .disabled(isDisabled)
+            #else
+            ToolbarButton(action: action, assetName: "ShareIcon", foregroundColor: Color("AccentColor"))
+                .disabled(isDisabled)
+            #endif
         }
     }
 
     @ViewBuilder
     func newChatButton() -> some View {
-        ToolbarButton(action: {
+        let action = {
             isTextEditorFocused = false
             isDeleteHistoryConfirmationVisible = true
             stop()
-        }, assetName: "NewChatIcon", foregroundColor: Color("LightGreen"))
-            .alert("Clear chat history?", isPresented: $isDeleteHistoryConfirmationVisible, actions: {
-                Button("Clear", action: deleteHistory)
-                Button("Cancel", role: .cancel) {
-                    isDeleteHistoryConfirmationVisible = false
-                }
-            })
-            .disabled(isDeleteButtonDisabled)
+        }
+
+        Group {
+            #if targetEnvironment(macCatalyst)
+            ToolbarButton(action: action, systemName: "plus.app", foregroundColor: Color("LightGreen"))
+            #else
+            ToolbarButton(action: action, assetName: "NewChatIcon", foregroundColor: Color("LightGreen"))
+            #endif
+        }
+        .alert("Clear chat history?", isPresented: $isDeleteHistoryConfirmationVisible, actions: {
+            Button("Clear", action: deleteHistory)
+            Button("Cancel", role: .cancel) {
+                isDeleteHistoryConfirmationVisible = false
+            }
+        })
+        .disabled(isDeleteButtonDisabled)
     }
 
     var body: some View {

--- a/OLMoE.swift/Views/InfoPageView.swift
+++ b/OLMoE.swift/Views/InfoPageView.swift
@@ -12,7 +12,11 @@ struct InfoButton: View {
     let action: () -> Void
 
     var body: some View {
+        #if targetEnvironment(macCatalyst)
+        ToolbarButton(action: action, systemName: "info.circle", foregroundColor: Color("AccentColor"))
+        #else
         ToolbarButton(action: action, assetName: "InfoIcon", foregroundColor: Color("AccentColor"))
+        #endif
     }
 }
 

--- a/OLMoE.swift/Views/MetricsView.swift
+++ b/OLMoE.swift/Views/MetricsView.swift
@@ -16,7 +16,7 @@ public struct MetricsButton: View {
     let isShowing: Bool
 
     public var body: some View {
-        ToolbarButton(action: action, systemName: isShowing ? "chart.bar.fill" : "chart.bar", foregroundColor: Color("AccentColor"))
+        ToolbarButton(action: action, systemName: isShowing ? "gauge.with.dots.needle.bottom.50percent.badge.minus" : "gauge.with.dots.needle.bottom.50percent.badge.plus", foregroundColor: Color("AccentColor"))
         #if targetEnvironment(macCatalyst)
             .padding(.trailing, 12)
             .padding(.top, 4)


### PR DESCRIPTION
# Describe the changes
- Updated `BotView`, `InfoButton`, and `MetricsButton` to use system icons for Mac Catalyst and asset names for other platforms.

## Issue ticket number and link
#206 

## Demo
![image](https://github.com/user-attachments/assets/b2243fef-1cf2-45ce-8f13-65e01127e105)

![image](https://github.com/user-attachments/assets/815dfac3-4f4f-4f2a-a9a7-abeffe2dc180)


## Checklist before requesting a review

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have tested my changes and ensured that they work as expected.
- [x] I have updated examples and documentation as necessary.
